### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     }
   ],
   "require": {
-    "illuminate/support": "5.*"
+    "illuminate/support": "5.0.* || 5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x`, `5.*` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.